### PR TITLE
chapter 03 flask 1.1.2 -> 2.0.3

### DIFF
--- a/chapter03/docker/events-api/requirements.txt
+++ b/chapter03/docker/events-api/requirements.txt
@@ -1,4 +1,4 @@
 click==7.1.2
 faker==4.14.0
-flask==1.1.2
+flask==2.0.3
 pandas==1.1.3


### PR DESCRIPTION
fix for the jinja2 import error

```
ImportError: cannot import name 'escape' from 'jinja2'
```