### PR TITLE
Update chapter08 requirements.txt

### DIFF
--- a/chapter08/docker/movielens-api/requirements.txt
+++ b/chapter08/docker/movielens-api/requirements.txt
@@ -2,3 +2,6 @@ Flask==1.1.1
 pandas==0.25.2
 Flask-HTTPAuth==3.3.0
 click==7.1.2
+Jinja2==3.0.3
+werkzeug==2.0.2
+itsdangerous==2.0.1


### PR DESCRIPTION
Fix Jinja2 version due to escape module was [dropped in newer versions of Jinja](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0).

Without it, I got the following error:

> ImportError: cannot import name 'escape' from 'jinja2'